### PR TITLE
Typed attribute access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Added
 * Added support for Python 3.11.
 * Added better error message for Bluetooth not authorized on macOS.
 * ``BleakDeviceNotFoundError`` which should be raised if a device can not be found by ``connect``, ``pair`` and ``unpair``
+* Added ``rssi`` attribute to ``AdvertisementData``.
+
+Changed
+-------
+Changed ``AdvertisementData`` to a named tuple.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Added
 * Added better error message for Bluetooth not authorized on macOS.
 * ``BleakDeviceNotFoundError`` which should be raised if a device can not be found by ``connect``, ``pair`` and ``unpair``
 * Added ``rssi`` attribute to ``AdvertisementData``.
+* Added ``BleakScanner.discovered_devices_and_advertisement_data`` property.
+* Added ``return_adv`` argument to ``BleakScanner.discover`` method.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,8 @@ Added
 
 Changed
 -------
-Changed ``AdvertisementData`` to a named tuple.
+* Changed ``AdvertisementData`` to a named tuple.
+* A faster ``unpack_variants`` is now provided by dbus-fast
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,7 +76,7 @@ Changed
   argument to avoid services being resolved again. Merged #923.
 * The BlueZ D-Bus backend now uses ``dbus-fast`` package instead of ``dbus-next`` which significantly improves performance. Merged #988.
 * The BlueZ D-Bus backend will not avoid trying to connect to devices that are already connected. Fixes #992.
-* Updated logging to lazy version and replaced format by f-string for BleakClientWinRT. #1000.
+* Updated logging to lazy version and replaced format by f-string for ``BleakClientWinRT``. #1000.
 * Added deprecation warning to ``discover()`` method. Merged #1005.
 * BlueZ adapter is chosen dynamically if not provided, instead of using hardcoded "hci0". Fixes #513.
 
@@ -110,7 +110,7 @@ Fixed
 Changed
 -------
 * Made BlueZ D-Bus signal callback logging lazy to improve performance. Merged #912.
-* Switch to using async_timeout instead of asyncio.wait_for for performance. Merged #916.
+* Switch to using ``async_timeout`` instead of ``asyncio.wait_for for performance``. Merged #916.
 * Improved performance of ``BlueZManager.get_services()``. Fixes #927.
 
 Removed

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -88,6 +88,14 @@ class BleakScanner:
             custom backend).
         **kwargs:
             Additional args for backwards compatibility.
+
+    .. versionchanged:: 0.15.0
+        ``detection_callback``, ``service_uuids`` and ``scanning_mode`` are no longer keyword-only.
+        Added ``bluez`` parameter.
+
+    .. versionchanged:: 0.18.0
+        No longer is alias for backend type and no longer inherits from :class:`BaseBleakScanner`.
+        Added ``backend`` parameter.
     """
 
     def __init__(
@@ -195,6 +203,9 @@ class BleakScanner:
         Returns:
             The value of :attr:`discovered_devices_and_advertisement_data` if
             ``return_adv`` is ``True``, otherwise the value of :attr:`discovered_devices`.
+
+        .. versionchanged:: 0.19.0
+            Added ``return_adv`` parameter.
         """
         async with cls(**kwargs) as scanner:
             await asyncio.sleep(timeout)
@@ -225,6 +236,8 @@ class BleakScanner:
         of known devices. If you don't need to do that, consider using
         ``discovered_devices_and_advertisement_data.values()`` to just get the
         values instead.
+
+        .. versionadded:: 0.19.0
         """
         return self._backend.seen_devices
 
@@ -342,6 +355,13 @@ class BleakClient:
             the :meth:`connect` method to implicitly call :meth:`BleakScanner.discover`.
             This is known to cause problems when trying to connect to multiple
             devices at the same time.
+
+    .. versionchanged:: 0.15.0
+        ``disconnected_callback`` is no longer keyword-only. Added ``winrt`` parameter.
+
+    .. versionchanged:: 0.18.0
+        No longer is alias for backend type and no longer inherits from :class:`BaseBleakClient`.
+        Added ``backend`` parameter.
     """
 
     def __init__(
@@ -579,6 +599,10 @@ class BleakClient:
                 The function to be called on notification. Can be regular
                 function or async function.
 
+
+        .. versionchanged:: 0.18.0
+            The first argument of the callback is now a :class:`BleakGATTCharacteristic`
+            instead of an ``int``.
         """
         if not self.is_connected:
             raise BleakError("Not connected")

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -175,7 +175,7 @@ class BleakScanner:
     @overload
     @classmethod
     async def discover(
-        cls, timeout: float = 5.0, *, return_adv: Literal[False], **kwargs
+        cls, timeout: float = 5.0, *, return_adv: Literal[False] = False, **kwargs
     ) -> List[BLEDevice]:
         ...
 

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -180,7 +180,7 @@ class BleakScanner:
         Returns:
             A list of the devices that the scanner has discovered during the scanning.
         """
-        return self._backend.discovered_devices
+        return [d for d, _ in self._backend.seen_devices.values()]
 
     async def get_discovered_devices(self) -> List[BLEDevice]:
         """Gets the devices registered by the BleakScanner.

--- a/bleak/assigned_numbers.py
+++ b/bleak/assigned_numbers.py
@@ -16,6 +16,8 @@ class AdvertisementDataType(IntEnum):
     Generic Access Profile advertisement data types.
 
     `Source <https://btprodspecificationrefs.blob.core.windows.net/assigned-numbers/Assigned%20Number%20Types/Generic%20Access%20Profile.pdf>`.
+
+    .. versionadded:: 0.15.0
     """
 
     FLAGS = 0x01

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -838,10 +838,9 @@ class BlueZManager:
         """
         for (callback, adapter_path) in self._advertisement_callbacks:
             # filter messages from other adapters
-            if not device_path.startswith(adapter_path):
+            if adapter_path != device["Adapter"]:
                 continue
 
-            # TODO: this should be deep copy, not shallow
             callback(device_path, device.copy())
 
 

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -24,7 +24,7 @@ from typing import (
 )
 from weakref import WeakKeyDictionary
 
-from dbus_fast import BusType, Message, MessageType, Variant
+from dbus_fast import BusType, Message, MessageType, Variant, unpack_variants
 from dbus_fast.aio.message_bus import MessageBus
 
 from ...exc import BleakError
@@ -36,7 +36,7 @@ from .defs import Device1, GattService1, GattCharacteristic1, GattDescriptor1
 from .descriptor import BleakGATTDescriptorBlueZDBus
 from .service import BleakGATTServiceBlueZDBus
 from .signals import MatchRules, add_match
-from .utils import assert_reply, unpack_variants
+from .utils import assert_reply
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    MutableMapping,
     NamedTuple,
     Optional,
     Set,
@@ -844,7 +845,7 @@ class BlueZManager:
             callback(device_path, device.copy())
 
 
-_global_instances: Dict[Any, BlueZManager] = WeakKeyDictionary()
+_global_instances: MutableMapping[Any, BlueZManager] = WeakKeyDictionary()
 
 
 async def get_global_bluez_manager() -> BlueZManager:

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -16,6 +16,7 @@ from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakSca
 from .advertisement_monitor import OrPatternLike
 from .defs import Device1
 from .manager import get_global_bluez_manager
+from .utils import bdaddr_from_device_path
 
 logger = logging.getLogger(__name__)
 
@@ -89,9 +90,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         # kwarg "device" is for backwards compatibility
         self._adapter: Optional[str] = kwargs.get("adapter", kwargs.get("device"))
 
-        # map of d-bus object path to d-bus object properties
-        self._devices: Dict[str, Device1] = {}
-
         # callback from manager for stopping scanning if it has been started
         self._stop: Optional[Callable[[], Coroutine]] = None
 
@@ -137,7 +135,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         else:
             adapter_path = manager.get_default_adapter()
 
-        self._devices.clear()
+        self.seen_devices = {}
 
         if self._scanning_mode == "passive":
             self._stop = await manager.passive_scan(
@@ -192,25 +190,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             else:
                 logger.warning("Filter '%s' is not currently supported." % k)
 
-    @property
-    def discovered_devices(self) -> List[BLEDevice]:
-        discovered_devices = []
-
-        for path, props in self._devices.items():
-            uuids = props.get("UUIDs", [])
-            manufacturer_data = props.get("ManufacturerData", {})
-            discovered_devices.append(
-                BLEDevice(
-                    props["Address"],
-                    props["Alias"],
-                    {"path": path, "props": props},
-                    props.get("RSSI", 0),
-                    uuids=uuids,
-                    manufacturer_data=manufacturer_data,
-                )
-            )
-        return discovered_devices
-
     # Helper methods
 
     def _handle_advertising_data(self, path: str, props: Device1) -> None:
@@ -221,11 +200,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             path: The D-Bus object path of the device.
             props: The D-Bus object properties of the device.
         """
-
-        self._devices[path] = props
-
-        if self._callback is None:
-            return
 
         # Get all the information wanted to pack in the advertisement data
         _local_name = props.get("Name")
@@ -244,18 +218,32 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             manufacturer_data=_manufacturer_data,
             service_data=_service_data,
             service_uuids=_service_uuids,
-            platform_data=props,
+            platform_data=(path, props),
             tx_power=tx_power,
         )
 
-        device = BLEDevice(
-            props["Address"],
-            props["Alias"],
-            {"path": path, "props": props},
-            props.get("RSSI", 0),
+        metadata = dict(
             uuids=_service_uuids,
             manufacturer_data=_manufacturer_data,
         )
+
+        try:
+            device, _ = self.seen_devices[props["Address"]]
+
+            device.metadata = metadata
+        except KeyError:
+            device = BLEDevice(
+                props["Address"],
+                props["Alias"],
+                {"path": path, "props": props},
+                props.get("RSSI", 0),
+                **metadata,
+            )
+
+        self.seen_devices[props["Address"]] = (device, advertisement_data)
+
+        if self._callback is None:
+            return
 
         self._callback(device, advertisement_data)
 
@@ -264,9 +252,10 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         Handles a device being removed from BlueZ.
         """
         try:
-            del self._devices[device_path]
+            bdaddr = bdaddr_from_device_path(device_path)
+            del self.seen_devices[bdaddr]
         except KeyError:
-            # The device will not have been added to self._devices if no
+            # The device will not have been added to self.seen_devices if no
             # advertising data was received, so this is expected to happen
             # occasionally.
             pass

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -11,7 +11,6 @@ else:
     from typing import Literal, TypedDict
 
 from ...exc import BleakError
-from ..device import BLEDevice
 from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
 from .advertisement_monitor import OrPatternLike
 from .defs import Device1
@@ -223,25 +222,12 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             platform_data=(path, props),
         )
 
-        metadata = dict(
-            uuids=_service_uuids,
-            manufacturer_data=_manufacturer_data,
+        device = self.create_or_update_device(
+            props["Address"],
+            props["Alias"],
+            {"path": path, "props": props},
+            advertisement_data,
         )
-
-        try:
-            device, _ = self.seen_devices[props["Address"]]
-
-            device.metadata = metadata
-        except KeyError:
-            device = BLEDevice(
-                props["Address"],
-                props["Alias"],
-                {"path": path, "props": props},
-                props.get("RSSI", 0),
-                **metadata,
-            )
-
-        self.seen_devices[props["Address"]] = (device, advertisement_data)
 
         if self._callback is None:
             return

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -218,8 +218,9 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             manufacturer_data=_manufacturer_data,
             service_data=_service_data,
             service_uuids=_service_uuids,
-            platform_data=(path, props),
             tx_power=tx_power,
+            rssi=props.get("RSSI", -127),
+            platform_data=(path, props),
         )
 
         metadata = dict(

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 import re
-from typing import Any, Dict
 
 from dbus_fast.constants import MessageType
 from dbus_fast.message import Message
-from dbus_fast.signature import Variant
 
 from ...exc import BleakError, BleakDBusError
 
@@ -25,24 +23,6 @@ def assert_reply(reply: Message):
 
 def validate_address(address):
     return _address_regex.match(address) is not None
-
-
-def unpack_variants(dictionary: Dict[str, Variant]) -> Dict[str, Any]:
-    """Recursively unpacks all ``Variant`` types in a dictionary to their
-    corresponding Python types.
-
-    ``dbus-next`` doesn't automatically do this, so this needs to be called on
-    all dictionaries ("a{sv}") returned from D-Bus messages.
-    """
-    unpacked = {}
-    for k, v in dictionary.items():
-        v = v.value if isinstance(v, Variant) else v
-        if isinstance(v, dict):
-            v = unpack_variants(v)
-        elif isinstance(v, list):
-            v = [x.value if isinstance(x, Variant) else x for x in v]
-        unpacked[k] = v
-    return unpacked
 
 
 def extract_service_handle_from_path(path):

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -50,3 +50,16 @@ def extract_service_handle_from_path(path):
         return int(path[-4:], 16)
     except Exception as e:
         raise BleakError(f"Could not parse service handle from path: {path}") from e
+
+
+def bdaddr_from_device_path(device_path: str) -> str:
+    """
+    Scrape the Bluetooth address from a D-Bus device path.
+
+    Args:
+        device_path: The D-Bus object path of the device.
+
+    Returns:
+        A Bluetooth address as a string.
+    """
+    return ":".join(device_path[-17:].split("_"))

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -85,6 +85,8 @@ class BleakGATTCharacteristic(abc.ABC):
         """
         Gets the maximum size in bytes that can be used for the *data* argument
         of :meth:`BleakClient.write_gatt_char()` when ``response=False``.
+
+        .. versionadded:: 0.16.0
         """
         return self._max_write_without_response_size
 

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -61,8 +61,6 @@ class CentralManagerDelegate(NSObject):
         self.event_loop = asyncio.get_running_loop()
         self._connect_futures: Dict[NSUUID, asyncio.Future] = {}
 
-        self.last_rssi: Dict[str, int] = {}
-
         self.callbacks: Dict[
             int, Callable[[CBPeripheral, Dict[str, Any], int], None]
         ] = {}
@@ -108,9 +106,6 @@ class CentralManagerDelegate(NSObject):
 
     @objc.python_method
     async def start_scan(self, service_uuids) -> None:
-        # remove old
-        self.last_rssi.clear()
-
         service_uuids = (
             NSArray.alloc().initWithArray_(
                 list(map(CBUUID.UUIDWithString_, service_uuids))
@@ -253,8 +248,6 @@ class CentralManagerDelegate(NSObject):
         # CBCentralManagerScanOptionAllowDuplicatesKey global setting.
 
         uuid_string = peripheral.identifier().UUIDString()
-
-        self.last_rssi[uuid_string] = RSSI
 
         for callback in self.callbacks.values():
             if callback:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -52,8 +52,10 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self._central_manager_delegate: Optional[CentralManagerDelegate] = None
 
         if isinstance(address_or_ble_device, BLEDevice):
-            self._peripheral = address_or_ble_device.details
-            self._central_manager_delegate = address_or_ble_device.metadata["delegate"]
+            (
+                self._peripheral,
+                self._central_manager_delegate,
+            ) = address_or_ble_device.details
 
         self._services: Optional[NSArray] = None
 
@@ -77,8 +79,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             )
 
             if device:
-                self._peripheral = device.details
-                self._central_manager_delegate = device.metadata["delegate"]
+                self._peripheral, self._central_manager_delegate = device.details
             else:
                 raise BleakDeviceNotFoundError(
                     self.address, f"Device with address {self.address} was not found"

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -104,12 +104,13 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             tx_power = a.get("kCBAdvDataTxPowerLevel")
 
             advertisement_data = AdvertisementData(
-                local_name=p.name(),
+                local_name=a.get("kCBAdvDataLocalName"),
                 manufacturer_data=manufacturer_data,
                 service_data=service_data,
                 service_uuids=service_uuids,
-                platform_data=(p, a, r),
                 tx_power=tx_power,
+                rssi=r,
+                platform_data=(p, a, r),
             )
 
             metadata = dict(

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -12,7 +12,6 @@ from CoreBluetooth import CBPeripheral
 from Foundation import NSBundle
 
 from ...exc import BleakError
-from ..device import BLEDevice
 from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
 from .CentralManagerDelegate import CentralManagerDelegate
 from .utils import cb_uuid_to_str
@@ -113,24 +112,12 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
                 platform_data=(p, a, r),
             )
 
-            metadata = dict(
-                uuids=service_uuids,
-                manufacturer_data=manufacturer_data,
+            device = self.create_or_update_device(
+                p.identifier().UUIDString(),
+                p.name(),
+                (p, self._manager.central_manager.delegate()),
+                advertisement_data,
             )
-
-            try:
-                device, _ = self.seen_devices[p.identifier().UUIDString()]
-                device.metadata = metadata
-            except KeyError:
-                device = BLEDevice(
-                    p.identifier().UUIDString(),
-                    p.name(),
-                    (p, self._manager.central_manager.delegate()),
-                    r,
-                    **metadata
-                )
-
-            self.seen_devices[device.address] = (device, advertisement_data)
 
             if not self._callback:
                 return

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -6,7 +6,6 @@ Wrapper class for Bluetooth LE servers returned from calling
 Created on 2018-04-23 by hbldh <henrik.blidh@nedomkull.com>
 
 """
-from ._manufacturers import MANUFACTURERS
 
 
 class BLEDevice:

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -36,17 +36,7 @@ class BLEDevice:
         self.metadata = kwargs
 
     def __str__(self):
-        if not self.name:
-            if "manufacturer_data" in self.metadata:
-                ks = list(self.metadata["manufacturer_data"].keys())
-                if len(ks):
-                    mf = MANUFACTURERS.get(ks[0], MANUFACTURERS.get(0xFFFF))
-                    value = self.metadata["manufacturer_data"].get(
-                        ks[0], MANUFACTURERS.get(0xFFFF)
-                    )
-                    # TODO: Evaluate how to interpret the value of the company identifier...
-                    return "{0}: {1} ({2})".format(self.address, mf, value)
-        return "{0}: {1}".format(self.address, self.name or "Unknown")
+        return f"{self.address}: {self.name}"
 
     def __repr__(self):
-        return str(self)
+        return f"BLEDevice({self.address}, {self.name})"

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -256,8 +256,9 @@ class BleakScannerP4Android(BaseBleakScanner):
             manufacturer_data=manufacturer_data,
             service_data=service_data,
             service_uuids=service_uuids,
-            platform_data=(result,),
             tx_power=tx_power,
+            rssi=native_device.getRssi(),
+            platform_data=(result,),
         )
 
         metadata = dict(

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -17,7 +17,6 @@ from android.permissions import Permission, request_permissions
 from jnius import cast, java_method
 
 from ...exc import BleakError
-from ..device import BLEDevice
 from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
 from . import defs, utils
 
@@ -261,23 +260,12 @@ class BleakScannerP4Android(BaseBleakScanner):
             platform_data=(result,),
         )
 
-        metadata = dict(
-            uuids=service_uuids,
-            manufacturer_data=manufacturer_data,
+        device = self.create_or_update_device(
+            native_device.getAddress(),
+            native_device.getName(),
+            native_device,
+            advertisement,
         )
-
-        try:
-            device, _ = self.seen_devices[native_device.getAddress()]
-            device.metadata = metadata
-        except KeyError:
-            device = BLEDevice(
-                native_device.getAddress(),
-                native_device.getName(),
-                native_device.getRssi(),
-                **metadata,
-            )
-
-        self.seen_devices[device.address] = (device, advertisement)
 
         if not self._callback:
             return

--- a/bleak/backends/p4android/utils.py
+++ b/bleak/backends/p4android/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import asyncio
 import logging
 import warnings
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 class AsyncJavaCallbacks(PythonJavaClass):
     __javacontext__ = "app"
 
-    def __init__(self, loop):
+    def __init__(self, loop: asyncio.AbstractEventLoop):
         self._loop = loop
         self.states = {}
         self.futures = {}

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -81,6 +81,13 @@ class BaseBleakScanner(abc.ABC):
             containing this advertising data will be received.
     """
 
+    seen_devices: Dict[str, Tuple[BLEDevice, AdvertisementData]]
+    """
+    Map of device identifier to BLEDevice and most recent advertisement data.
+
+    This map must be cleared when scanning starts.
+    """
+
     def __init__(
         self,
         detection_callback: Optional[AdvertisementDataCallback],
@@ -92,6 +99,8 @@ class BaseBleakScanner(abc.ABC):
         self._service_uuids: Optional[List[str]] = (
             [u.lower() for u in service_uuids] if service_uuids is not None else None
         )
+
+        self.seen_devices = {}
 
     def register_detection_callback(
         self, callback: Optional[AdvertisementDataCallback]
@@ -144,16 +153,6 @@ class BaseBleakScanner(abc.ABC):
         Args:
             **kwargs: The filter details. This will differ a lot between backend implementations.
 
-        """
-        raise NotImplementedError()
-
-    @property
-    @abc.abstractmethod
-    def discovered_devices(self) -> List[BLEDevice]:
-        """Gets the devices registered by the BleakScanner.
-
-        Returns:
-            A list of the devices that the scanner has discovered during the scanning.
         """
         raise NotImplementedError()
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -3,44 +3,57 @@ import asyncio
 import inspect
 import os
 import platform
-from typing import Awaitable, Callable, Dict, List, Optional, Tuple, Type
+from typing import Awaitable, Callable, Dict, List, NamedTuple, Optional, Tuple, Type
 
 from ..exc import BleakError
 from .device import BLEDevice
 
 
-class AdvertisementData:
+class AdvertisementData(NamedTuple):
     """
     Wrapper around the advertisement data that each platform returns upon discovery
     """
 
-    def __init__(self, **kwargs):
-        """
-        Keyword Args:
-            local_name (str): The name of the ble device advertising
-            manufacturer_data (dict): Manufacturer data from the device
-            service_data (dict): Service data from the device
-            service_uuids (list): UUIDs associated with the device
-            platform_data (tuple): Tuple of platform specific advertisement data
-            tx_power (int): Transmit power level of the device
-        """
-        # The local name of the device
-        self.local_name: Optional[str] = kwargs.get("local_name", None)
+    local_name: Optional[str]
+    """
+    The local name of the device or ``None`` if not included in advertising data.
+    """
 
-        # Dictionary of manufacturer data in bytes
-        self.manufacturer_data: Dict[int, bytes] = kwargs.get("manufacturer_data", {})
+    manufacturer_data: Dict[int, bytes]
+    """
+    Dictionary of manufacturer data in bytes from the received advertisement data or empty dict if not present.
 
-        # Dictionary of service data
-        self.service_data: Dict[str, bytes] = kwargs.get("service_data", {})
+    The keys are Bluetooth SIG assigned Company Identifiers and the values are bytes.
 
-        # List of UUIDs
-        self.service_uuids: List[str] = kwargs.get("service_uuids", [])
+    https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
+    """
 
-        # Tuple of platform specific data
-        self.platform_data: Tuple = kwargs.get("platform_data", ())
+    service_data: Dict[str, bytes]
+    """
+    Dictionary of service data from the received advertisement data or empty dict if not present.
+    """
 
-        # Tx Power data
-        self.tx_power: Optional[int] = kwargs.get("tx_power")
+    service_uuids: List[str]
+    """
+    List of service UUIDs from the received advertisement data or empty list if not present.
+    """
+
+    tx_power: Optional[int]
+    """
+    Tx Power data from the received advertising data or ``None`` if not present.
+    """
+
+    rssi: int
+    """
+    The Radio Receive Signal Strength (RSSI) in dBm.
+    """
+
+    platform_data: Tuple
+    """
+    Tuple of platform specific data.
+
+    This is not a stable API. The actual values may change between releases.
+    """
 
     def __repr__(self) -> str:
         kwargs = []
@@ -54,6 +67,7 @@ class AdvertisementData:
             kwargs.append(f"service_uuids={repr(self.service_uuids)}")
         if self.tx_power is not None:
             kwargs.append(f"tx_power={repr(self.tx_power)}")
+        kwargs.append(f"rssi={repr(self.rssi)}")
         return f"AdvertisementData({', '.join(kwargs)})"
 
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -51,11 +51,15 @@ class AdvertisementData(NamedTuple):
     tx_power: Optional[int]
     """
     Tx Power data from the received advertising data or ``None`` if not present.
+
+    .. versionadded:: 0.17.0
     """
 
     rssi: int
     """
     The Radio Receive Signal Strength (RSSI) in dBm.
+
+    .. versionadded:: 0.19.0
     """
 
     platform_data: Tuple

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -89,11 +89,19 @@ AdvertisementDataCallback = Callable[
     [BLEDevice, AdvertisementData],
     Optional[Awaitable[None]],
 ]
+"""
+Type alias for callback called when advertisement data is received.
+"""
 
 AdvertisementDataFilter = Callable[
     [BLEDevice, AdvertisementData],
     bool,
 ]
+"""
+Type alias for an advertisement data filter function.
+
+Implementations should return ``True`` for matches, otherwise ``False``.
+"""
 
 
 class BaseBleakScanner(abc.ABC):

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -176,8 +176,9 @@ class BleakScannerWinRT(BaseBleakScanner):
             manufacturer_data=mfg_data,
             service_data=service_data,
             service_uuids=uuids,
-            platform_data=(sender, raw_data),
             tx_power=tx_power,
+            rssi=event_args.raw_signal_strength_in_d_bm,
+            platform_data=(sender, raw_data),
         )
 
         metadata = dict(

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import sys
-from typing import Dict, List, NamedTuple, Optional
+from typing import List, NamedTuple, Optional, cast
 from uuid import UUID
 
 from bleak_winrt.windows.devices.bluetooth.advertisement import (
@@ -83,7 +83,6 @@ class BleakScannerWinRT(BaseBleakScanner):
 
         self.watcher = None
         self._stopped_event = None
-        self._discovered_devices: Dict[int, _RawAdvData] = {}
 
         # case insensitivity is for backwards compatibility on Windows only
         if scanning_mode.lower() == "passive":
@@ -106,43 +105,51 @@ class BleakScannerWinRT(BaseBleakScanner):
         # TODO: Cannot check for if sender == self.watcher in winrt?
         logger.debug("Received {0}.".format(_format_event_args(event_args)))
 
-        # get the previous advertising data or start a new one
-        raw_data = self._discovered_devices.get(
-            event_args.bluetooth_address, _RawAdvData(event_args, None)
+        # REVISIT: if scanning filters with BluetoothSignalStrengthFilter.OutOfRangeTimeout
+        # are in place, an RSSI of -127 means that the device has gone out of range and should
+        # be removed from the list of seen devices instead of processing the advertisement data.
+        # https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothsignalstrengthfilter.outofrangetimeout
+
+        bdaddr = _format_bdaddr(event_args.bluetooth_address)
+
+        # Unlike other platforms, Windows does not combine advertising data for
+        # us (regular advertisement + scan response) so we have to do it manually.
+
+        # get the previous advertising data/scan response pair or start a new one
+        _, old_adv_data = self.seen_devices.get(bdaddr, (None, None))
+        raw_data = (
+            _RawAdvData(event_args, None)
+            if old_adv_data is None
+            else cast(_RawAdvData, old_adv_data.platform_data[1])
         )
 
-        # update the advertsing data depending on the advertising data type
+        # update the advertising data depending on the advertising data type
         if event_args.advertisement_type == BluetoothLEAdvertisementType.SCAN_RESPONSE:
             raw_data = _RawAdvData(raw_data.adv, event_args)
         else:
             raw_data = _RawAdvData(event_args, raw_data.scan)
 
-        self._discovered_devices[event_args.bluetooth_address] = raw_data
-
-        if self._callback is None:
-            return
-
-        # Get a "BLEDevice" from parse_event args
-        device = self._parse_adv_data(raw_data)
-
-        # On Windows, we have to fake service UUID filtering. If we were to pass
-        # a BluetoothLEAdvertisementFilter to the BluetoothLEAdvertisementWatcher
-        # with the service UUIDs appropriately set, we would no longer receive
-        # scan response data (which commonly contains the local device name).
-        # So we have to do it like this instead.
-
-        if self._service_uuids:
-            for uuid in device.metadata["uuids"]:
-                if uuid in self._service_uuids:
-                    break
-            else:
-                # if there were no matching service uuids, the don't call the callback
-                return
-
+        uuids = []
+        mfg_data = {}
         service_data = {}
+        local_name = None
+        tx_power = None
 
-        # Decode service data
         for args in filter(lambda d: d is not None, raw_data):
+            for u in args.advertisement.service_uuids:
+                uuids.append(str(u))
+
+            for m in args.advertisement.manufacturer_data:
+                mfg_data[m.company_id] = bytes(m.data)
+
+            # local name is empty string rather than None if not present
+            if args.advertisement.local_name:
+                local_name = args.advertisement.local_name
+
+            if args.transmit_power_level_in_d_bm is not None:
+                tx_power = raw_data.adv.transmit_power_level_in_d_bm
+
+            # Decode service data
             for section in args.advertisement.get_sections_by_type(
                 AdvertisementDataType.SERVICE_DATA_UUID16
             ):
@@ -163,32 +170,66 @@ class BleakScannerWinRT(BaseBleakScanner):
                 data = bytes(section.data)
                 service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
 
-        # get transmit power level data
-        tx_power = raw_data.adv.transmit_power_level_in_d_bm
-
         # Use the BLEDevice to populate all the fields for the advertisement data to return
         advertisement_data = AdvertisementData(
-            local_name=device.name,
-            manufacturer_data=device.metadata["manufacturer_data"],
+            local_name=local_name,
+            manufacturer_data=mfg_data,
             service_data=service_data,
-            service_uuids=device.metadata["uuids"],
+            service_uuids=uuids,
             platform_data=(sender, raw_data),
             tx_power=tx_power,
         )
+
+        metadata = dict(
+            uuids=uuids,
+            manufacturer_data=mfg_data,
+        )
+
+        try:
+            device, _ = self.seen_devices[bdaddr]
+
+            device.metadata = metadata
+        except KeyError:
+            device = BLEDevice(
+                bdaddr,
+                local_name,
+                sender,
+                event_args.raw_signal_strength_in_d_bm,
+                **metadata,
+            )
+
+        self.seen_devices[device.address] = (device, advertisement_data)
+
+        if self._callback is None:
+            return
+
+        # On Windows, we have to fake service UUID filtering. If we were to pass
+        # a BluetoothLEAdvertisementFilter to the BluetoothLEAdvertisementWatcher
+        # with the service UUIDs appropriately set, we would no longer receive
+        # scan response data (which commonly contains the local device name).
+        # So we have to do it like this instead.
+
+        if self._service_uuids:
+            for uuid in uuids:
+                if uuid in self._service_uuids:
+                    break
+            else:
+                # if there were no matching service uuids, the don't call the callback
+                return
 
         self._callback(device, advertisement_data)
 
     def _stopped_handler(self, sender, e):
         logger.debug(
             "{0} devices found. Watcher status: {1}.".format(
-                len(self._discovered_devices), self.watcher.status
+                len(self.seen_devices), self.watcher.status
             )
         )
         self._stopped_event.set()
 
     async def start(self):
         # start with fresh list of discovered devices
-        self._discovered_devices.clear()
+        self.seen_devices = {}
 
         self.watcher = BluetoothLEAdvertisementWatcher()
         self.watcher.scanning_mode = self._scanning_mode
@@ -243,31 +284,3 @@ class BleakScannerWinRT(BaseBleakScanner):
         if "AdvertisementFilter" in kwargs:
             # TODO: Handle AdvertisementFilter parameters
             self._advertisement_filter = kwargs["AdvertisementFilter"]
-
-    @property
-    def discovered_devices(self) -> List[BLEDevice]:
-        return [self._parse_adv_data(d) for d in self._discovered_devices.values()]
-
-    @staticmethod
-    def _parse_adv_data(raw_data: _RawAdvData) -> BLEDevice:
-        """
-        Combines advertising data from regular advertisement data and scan response.
-        """
-        bdaddr = _format_bdaddr(raw_data.adv.bluetooth_address)
-        uuids = []
-        data = {}
-        local_name = None
-
-        for args in filter(lambda d: d is not None, raw_data):
-            for u in args.advertisement.service_uuids:
-                uuids.append(str(u))
-            for m in args.advertisement.manufacturer_data:
-                data[m.company_id] = bytes(m.data)
-            # local name is empty string rather than None if not present
-            if args.advertisement.local_name:
-                local_name = args.advertisement.local_name
-            rssi = args.raw_signal_strength_in_d_bm
-
-        return BLEDevice(
-            bdaddr, local_name, raw_data, rssi, uuids=uuids, manufacturer_data=data
-        )

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -181,7 +181,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         )
 
         device = self.create_or_update_device(
-            bdaddr, local_name, sender, advertisement_data
+            bdaddr, local_name, raw_data, advertisement_data
         )
 
         if self._callback is None:

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -16,7 +16,6 @@ if sys.version_info[:2] < (3, 8):
 else:
     from typing import Literal
 
-from ..device import BLEDevice
 from ..scanner import AdvertisementDataCallback, BaseBleakScanner, AdvertisementData
 from ...assigned_numbers import AdvertisementDataType
 
@@ -181,25 +180,9 @@ class BleakScannerWinRT(BaseBleakScanner):
             platform_data=(sender, raw_data),
         )
 
-        metadata = dict(
-            uuids=uuids,
-            manufacturer_data=mfg_data,
+        device = self.create_or_update_device(
+            bdaddr, local_name, sender, advertisement_data
         )
-
-        try:
-            device, _ = self.seen_devices[bdaddr]
-
-            device.metadata = metadata
-        except KeyError:
-            device = BLEDevice(
-                bdaddr,
-                local_name,
-                sender,
-                event_args.raw_signal_strength_in_d_bm,
-                **metadata,
-            )
-
-        self.seen_devices[device.address] = (device, advertisement_data)
 
         if self._callback is None:
             return

--- a/bleak/exc.py
+++ b/bleak/exc.py
@@ -12,6 +12,8 @@ class BleakDeviceNotFoundError(BleakError):
     """
     Exception which is raised if a device can not be found by ``connect``, ``pair`` and ``unpair``.
     This is the case if the OS Bluetooth stack has never seen this device or it was removed and forgotten.
+
+    .. versionadded: 0.19.0
     """
 
     identifier: str

--- a/bleak/pythonic/client.py
+++ b/bleak/pythonic/client.py
@@ -1,0 +1,68 @@
+from typing import Union, Any
+import uuid
+from bleak import BleakClient
+from bleak.exc import BleakError
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.pythonic.marshall import BleakGATTMarshaller
+
+
+class BleakPythonicClient(BleakClient):
+    __doc__ = BleakClient.__doc__ + """
+    
+    This is a subclass of BleakClient, currently with only two methods
+    added. To be extended with accessors.
+    """
+    async def read_gatt_char_typed(
+        self,
+        char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
+        **kwargs
+    ) -> Any:
+        """Perform read operation on the specified GATT characteristic.
+        The data returned is unmarshalled into native Python form based on the type information in the char_specifier.
+
+        Args:
+            char_specifier (BleakGATTCharacteristic): The characteristic to read from.
+        Returns:
+            The read data.
+
+        """
+        marshaller = await self.get_marshaller(char_specifier)
+        data_bytes = await self.read_gatt_char(char_specifier, **kwargs)
+        data = marshaller.unmarshall(data_bytes)
+        return data
+
+    async def write_gatt_char_typed(
+        self,
+        char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
+        data: Any,
+        response: bool = False,
+    ) -> None:
+        """Perform a write operation on the specified GATT characteristic.
+        The data to write is marshalled based on the type information in the characteristic.
+
+        Args:
+            char_specifier (BleakGATTCharacteristic): The characteristic to write.
+            data: The data to write.
+            response (bool): If write-with-response operation should be done. Defaults to `False`.
+
+        """
+        marshaller = await self.get_marshaller(char_specifier)
+        data_bytes = marshaller.marshall(data)
+        return await self.write_gatt_char(char_specifier, data_bytes, response)
+
+    async def get_marshaller(
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
+    ) -> BleakGATTMarshaller:
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            coll = await self.get_services()
+            char = coll.get_characteristic(char_specifier)
+            if not char:
+                raise BleakError(f"Unknown characteristic {char_specifier}")
+            char_specifier = char
+        assert isinstance(char_specifier, BleakGATTCharacteristic)
+        descr_2904 = char_specifier.get_descriptor(
+            "00002904-0000-1000-8000-00805f9b34fb"
+        )
+        return await BleakGATTMarshaller.get_marshaller(
+            descr_2904=descr_2904, uuid=char_specifier.uuid, client=self
+        )

--- a/bleak/pythonic/client.py
+++ b/bleak/pythonic/client.py
@@ -7,15 +7,19 @@ from bleak.pythonic.marshall import BleakGATTMarshaller
 
 
 class BleakPythonicClient(BleakClient):
-    __doc__ = BleakClient.__doc__ + """
+    __doc__ = (
+        BleakClient.__doc__
+        + """
     
     This is a subclass of BleakClient, currently with only two methods
     added. To be extended with accessors.
     """
+    )
+
     async def read_gatt_char_typed(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        **kwargs
+        **kwargs,
     ) -> Any:
         """Perform read operation on the specified GATT characteristic.
         The data returned is unmarshalled into native Python form based on the type information in the char_specifier.

--- a/bleak/pythonic/client.py
+++ b/bleak/pythonic/client.py
@@ -54,7 +54,7 @@ class BleakPythonicClient(BleakClient):
         self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
     ) -> BleakGATTMarshaller:
         if not isinstance(char_specifier, BleakGATTCharacteristic):
-            coll = await self.get_services()
+            coll = self.services
             char = coll.get_characteristic(char_specifier)
             if not char:
                 raise BleakError(f"Unknown characteristic {char_specifier}")

--- a/bleak/pythonic/marshall.py
+++ b/bleak/pythonic/marshall.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+import abc
+import enum
+from uuid import UUID
+from typing import List, Union, Any
+import struct
+import warnings
+from bleak import BleakClient
+
+
+def str2bytes(s: str) -> bytes:
+    return s.encode("utf8")
+
+
+def bytes2str(b: bytes) -> str:
+    return b.decode("utf8")
+
+
+Table_2904_bytes_format = {
+    1: (bool, bool, 1, "<?"),  # Boolean
+    2: (int, int, 1, "<B"),  # unsigned 2-bit int
+    3: (int, int, 1, "<B"),  # unsigned 4-bit int
+    4: (int, int, 1, "<B"),  # unsigned 8-bit int
+    5: (int, int, 2, "<H"),  # unsigned 12-bit int
+    6: (int, int, 2, "<H"),  # unsigned 16-bit int
+    #    7 : (int, int, 3, ''),   # unsigned 24-bit int
+    8: (int, int, 4, "<I"),  # unsigned 32-bit int
+    #    9 : (int, int, 6, ''),   # unsigned 48-bit int
+    10: (int, int, 8, "<Q"),  # unsigned 64-bit int
+    #    11 : (int, int, 16, ''),   # unsigned 128-bit int
+    12: (int, int, 1, "<b"),  # 8-bit int
+    13: (int, int, 2, "<h"),  # 12-bit int
+    14: (int, int, 2, "<h"),  # 16-bit int
+    #    15 : (int, int, 3, ''),   # 24-bit int
+    16: (int, int, 4, "<i"),  # 32-bit int
+    #    17 : (int, int, 6, ''),   # 48-bit int
+    18: (int, int, 8, "<Q"),  # 64-bit int
+    #    19 : (int, int, 16, ''),   # 128-bit int
+    20: (float, float, 4, "<f"),  # 32-bit float
+    21: (float, float, 8, "<d"),  # 64-bit double
+    25: (str2bytes, bytes2str, None, None),  # UTF8 string
+    27: (bytes, bytes, None, None),  # Opaque structure
+}
+
+# This table can be filled (eventually) with external marshaller sources.
+# It could also be used for caching, if we think that is safe.
+Table_uuid_to_marshaller = {}
+
+
+class BleakGATTMarshaller(abc.ABC):
+    """Marshall and unmarshall a GATT characteristic, converting between Python values and raw byte values."""
+
+    @classmethod
+    async def get_marshaller(
+        klass, client: BleakClient, uuid: str, descr_2904=None
+    ) -> Any:
+        """Obtain a marshaller object."""
+        if uuid:
+            if uuid in Table_uuid_to_marshaller:
+                return Table_uuid_to_marshaller[uuid]()
+        if descr_2904:
+            descr_2904_data = await client.read_gatt_descriptor(descr_2904.handle)
+            format, exponent, unit, namespace, description = struct.unpack(
+                "<BbHBH", descr_2904_data
+            )
+            if format in Table_2904_bytes_format:
+                m = BleakGATTPackMarshaller(
+                    Table_2904_bytes_format[format], exponent, unit
+                )
+                # We could add the marshaller to the table here, if we have a uuid
+                return m
+        warnings.warn(
+            f"BleakGATTMarshaller: no marshaller found for client {client.address} characteristic {uuid}"
+        )
+        return BleakGATTMarshaller()
+
+    @staticmethod
+    def marshall(data: Any) -> bytes:
+        """Convert data from Python format to raw bytes, for writing a characteristic."""
+        return bytes(data)
+
+    @staticmethod
+    def unmarshall(data_bytes: bytes) -> Any:
+        """Convert data from raw bytes to Python, for reading a characteristic."""
+        return data_bytes
+
+
+class BleakGATTPackMarshaller(BleakGATTMarshaller):
+    def __init__(self, format, exponent, unit):
+        self.frompython, self.topython, self.length, self.format = format
+        self.exponent = exponent
+        if self.exponent != 0:
+            print(
+                f"BleakGATTPackMarshaller: Warning: exponent not yet implemented",
+                file=sys.stderr,
+            )
+        self.unit = unit
+        # There does not seem to be anything useful to do with unit.
+
+    def marshall(self, data: Any) -> bytes:
+        if not self.length:
+            return self.frompython(data)
+        if self.exponent > 0:
+            data = data / (10 ** self.exponent)
+        elif self.exponent < 0:
+            data = data * (10 ** -self.exponent)
+        data = self.frompython(data)
+        data_bytes = struct.pack(self.format, data)
+        assert len(data_bytes) == self.length
+        return data_bytes
+
+    def unmarshall(self, data_bytes: bytes) -> Any:
+        if not self.length:
+            return self.topython(data_bytes)
+        assert len(data_bytes) == self.length
+        (data,) = struct.unpack(self.format, data_bytes)
+        data = self.topython(data)
+        if self.exponent != 0:
+            data = data * (10.0 ** self.exponent)
+        return data

--- a/bleak/pythonic/marshall.py
+++ b/bleak/pythonic/marshall.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 import abc
 import enum
 from uuid import UUID
@@ -6,7 +7,6 @@ from typing import List, Union, Any
 import struct
 import warnings
 from bleak import BleakClient
-
 
 def str2bytes(s: str) -> bytes:
     return s.encode("utf8")

--- a/docs/api/scanner.rst
+++ b/docs/api/scanner.rst
@@ -29,7 +29,7 @@ and stop scanning is to use it in an ``async with`` statement::
     import asyncio
     from bleak import BleakScanner
 
-    def main():
+    async def main():
         stop_event = asyncio.Event()
 
         # TODO: add something that calls stop_event.set()

--- a/docs/api/scanner.rst
+++ b/docs/api/scanner.rst
@@ -2,6 +2,8 @@
 BleakScanner class
 ==================
 
+.. py:currentmodule:: bleak
+
 .. autoclass:: bleak.BleakScanner
 
 
@@ -14,7 +16,6 @@ more advanced use cases like long running programs, GUIs or connecting to
 multiple devices.
 
 .. automethod:: bleak.BleakScanner.discover
-.. autoproperty:: bleak.BleakScanner.discovered_devices
 .. automethod:: bleak.BleakScanner.find_device_by_address
 .. automethod:: bleak.BleakScanner.find_device_by_filter
 
@@ -56,6 +57,21 @@ following methods:
 .. automethod:: bleak.BleakScanner.start
 .. automethod:: bleak.BleakScanner.stop
 
+-------------------------------------------------
+Getting discovered devices and advertisement data
+-------------------------------------------------
+
+If you aren't using the "easy" class methods, there are two ways to get the
+discovered devices and advertisement data.
+
+For event-driven programming, you can provide a ``detection_callback`` callback
+to the :class:`BleakScanner` constructor. This will be called back each time
+and advertisement is received.
+
+Otherwise, you can use one of the properties below after scanning has stopped.
+
+.. autoproperty:: bleak.BleakScanner.discovered_devices
+.. autoproperty:: bleak.BleakScanner.discovered_devices_and_advertisement_data
 
 ----------
 Deprecated

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
-    logger.info(f"{device.address} RSSI: {device.rssi}, {advertisement_data}")
+    logger.info(f"{device.address}: {advertisement_data}")
 
 
 async def main(service_uuids):

--- a/examples/discover.py
+++ b/examples/discover.py
@@ -14,9 +14,15 @@ from bleak import BleakScanner
 
 
 async def main():
-    devices = await BleakScanner.discover()
-    for d in devices:
+    print("scanning for 5 seconds, please wait...")
+
+    devices = await BleakScanner.discover(return_adv=True)
+
+    for d, a in devices.values():
+        print()
         print(d)
+        print("-" * len(str(d)))
+        print(a)
 
 
 if __name__ == "__main__":

--- a/examples/discover_all.py
+++ b/examples/discover_all.py
@@ -1,0 +1,74 @@
+"""
+Scan/Discovery
+--------------
+
+Example showing how to scan for BLE devices.
+
+Updated on 2019-03-25 by hbldh <henrik.blidh@nedomkull.com>
+
+"""
+
+import asyncio
+
+from bleak import BleakScanner, BLEDevice, AdvertisementData, BleakError
+from bleak import uuids
+from bleak.pythonic.client import BleakPythonicClient
+
+DEVICES_SEEN_BEFORE = {}
+
+async def detection_callback(device : BLEDevice, advData : AdvertisementData):
+    if device.name and device.name != "Unknown":
+        device_name = device.name
+    else:
+        device_name = device.address
+    if device_name in DEVICES_SEEN_BEFORE:
+        return
+    print(f"{device_name}:")
+    DEVICES_SEEN_BEFORE[device_name] = True
+    async with BleakPythonicClient(device) as conn:
+        services_seen_before = {}
+        for s in conn.services:
+            service_uuid = s.uuid
+            service_name = uuids.uuidstr_to_str(service_uuid)
+            if not service_name or service_name == "Unknown":
+                if s.description and s.description != "Unknown":
+                    service_name = s.description
+                else:
+                    service_name = service_uuid
+            if service_name in services_seen_before:
+                continue
+            services_seen_before[service_name] = True
+            print(f"\t{service_name}:")
+            chars_seen_before = {}
+            for c in s.characteristics:
+                char_uuid = c.uuid
+                char_name = uuids.uuidstr_to_str(char_uuid)
+                if not char_name or char_name == "Unknown":
+                    if c.description and c.description != "Unknown":
+                        char_name = c.description
+                    else:
+                        char_name = char_uuid
+                if char_name == chars_seen_before:
+                    continue
+                chars_seen_before[char_name] = True
+                print(f"\t\t{char_name}:")
+                try:
+                    value = await conn.read_gatt_char_typed(c)
+                    print(f"\t\t\t{value}")
+                except BleakError as e:
+                    print(f"\t\t\tError: {e}")
+
+EXECUTE_ASYNC = False
+async def main():
+    if EXECUTE_ASYNC:
+        scanner = BleakScanner(detection_callback=detection_callback)
+        await scanner.start()
+        await asyncio.sleep(10)
+        await scanner.stop()
+    else:
+        devices = await BleakScanner.discover(10)
+        for d in devices:
+            await detection_callback(d, None)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/get.py
+++ b/examples/get.py
@@ -1,0 +1,38 @@
+"""
+Get value for a single characteristic
+
+"""
+
+import sys
+import platform
+import asyncio
+import logging
+import re
+
+from bleak import BleakScanner
+from bleak.pythonic.client import BleakPythonicClient
+
+device = sys.argv[1]
+characteristic = sys.argv[2]
+
+
+async def run(device, charachteristic):
+    # If the device is specified by name we look it up
+    if re.fullmatch("[0-9a-fA-F:-]*", device):
+        dev = await BleakScanner.find_device_by_address(device)
+    else:
+        dev = await BleakScanner.find_device_by_filter(
+            lambda d, ad: d.name and d.name.lower() == device
+        )
+    if not dev:
+        print(f"Device {device} not found")
+        return
+    async with BleakPythonicClient(dev) as client:
+        value = await client.read_gatt_char_typed(characteristic)
+    print(value)
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+    loop.run_until_complete(run(device, characteristic))

--- a/examples/get.py
+++ b/examples/get.py
@@ -33,6 +33,4 @@ async def run(device, charachteristic):
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.set_debug(True)
-    loop.run_until_complete(run(device, characteristic))
+    asyncio.run(run(device, characteristic))

--- a/examples/kivy/main.py
+++ b/examples/kivy/main.py
@@ -52,7 +52,7 @@ class ExampleApp(App):
                 scanned_devices.sort(key=lambda device: -device.rssi)
 
                 for device in scanned_devices:
-                    self.line(f"{device.name} {device.rssi}dB")
+                    self.line(f"{device.name} ({device.address})")
 
                 for device in scanned_devices:
                     self.line(f"Connecting to {device.name} ...")

--- a/examples/set.py
+++ b/examples/set.py
@@ -1,0 +1,38 @@
+"""
+Get value for a single characteristic
+
+"""
+
+import sys
+import platform
+import asyncio
+import logging
+import re
+
+from bleak import BleakScanner
+from bleak.pythonic.client import BleakPythonicClient
+
+device = sys.argv[1]
+characteristic = sys.argv[2]
+value = sys.argv[3]
+
+
+async def run(device, charachteristic, value):
+    # If the device is specified by name we look it up
+    if re.fullmatch("[0-9a-fA-F:-]*", device):
+        dev = await BleakScanner.find_device_by_address(device)
+    else:
+        dev = await BleakScanner.find_device_by_filter(
+            lambda d, ad: d.name and d.name.lower() == device
+        )
+    if not dev:
+        print(f"Device {device} not found")
+        return
+    async with BleakPythonicClient(dev) as client:
+        await client.write_gatt_char_typed(characteristic, value, True)
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+    loop.run_until_complete(run(device, characteristic, value))

--- a/examples/set.py
+++ b/examples/set.py
@@ -33,6 +33,4 @@ async def run(device, charachteristic, value):
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.set_debug(True)
-    loop.run_until_complete(run(device, characteristic, value))
+    asyncio.run(run(device, characteristic, value))

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,14 +136,17 @@ toml = ["tomli"]
 
 [[package]]
 name = "dbus-fast"
-version = "1.4.0"
+version = "1.22.0"
 description = "A faster version of dbus-next"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 
+[package.dependencies]
+async-timeout = ">=3.0.0"
+
 [package.extras]
-docs = ["Sphinx[docs] (>=5.1.1,<6.0.0)", "myst-parser[docs] (>=0.18.0,<0.19.0)", "sphinx-rtd-theme[docs] (>=1.0.0,<2.0.0)", "sphinxcontrib-asyncio[docs] (>=0.3.0,<0.4.0)", "sphinxcontrib-fulltoc[docs] (>=1.2.0,<2.0.0)"]
+docs = ["Sphinx (>=5.1.1,<6.0.0)", "myst-parser (>=0.18.0,<0.19.0)", "sphinx-rtd-theme (>=1.0.0,<2.0.0)", "sphinxcontrib-asyncio (>=0.3.0,<0.4.0)", "sphinxcontrib-fulltoc (>=1.2.0,<2.0.0)"]
 
 [[package]]
 name = "docutils"
@@ -634,7 +637,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "1baccbd19a79f6819285c23f106c2d3a0d77d6279100a48ab1e2534450138e09"
+content-hash = "de7999d44b4fa4c454de85be9523558c9d375983122f54d97a97440fb25e558a"
 
 [metadata.files]
 alabaster = [
@@ -764,8 +767,34 @@ coverage = [
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
 dbus-fast = [
-    {file = "dbus-fast-1.4.0.tar.gz", hash = "sha256:292fec563d27f39bdc46d0a7d03320ff2d77f5f336bd8f564fe186946a213764"},
-    {file = "dbus_fast-1.4.0-py3-none-any.whl", hash = "sha256:3fea12c425587bb2b552e60e40bfcda2d3b94e77a8b2a30ec07c5bbc187bc984"},
+    {file = "dbus-fast-1.22.0.tar.gz", hash = "sha256:de6936cd4f70eb094051167d2faa1547c1088966f60f444e5732d1c6315fa64b"},
+    {file = "dbus_fast-1.22.0-cp310-cp310-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:a61153714e637492de9935ae1a0c6c6e7a2d470eb8b6b97b76702ab04216460f"},
+    {file = "dbus_fast-1.22.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96a93b08d7dd896734e6a022ce631906e773a9d10d397f26f96906583c7020a9"},
+    {file = "dbus_fast-1.22.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f3667a2c2753aafa042dbe252ad57e562c2e2fe2e9556042b376561d660ad176"},
+    {file = "dbus_fast-1.22.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cbc8c6e2b62987dbb48aa22f8c6d3d48e53d04629773d58a3f34342920cac251"},
+    {file = "dbus_fast-1.22.0-cp311-cp311-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:f072d5e7400e5956a56ead71c92a975b0438b36e7694b3d10afe1af9ede456d9"},
+    {file = "dbus_fast-1.22.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86d5abdddd19deef483a7e5628fff073d34b050e9edc462bf0246da04e754006"},
+    {file = "dbus_fast-1.22.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:f2036ffd7f4fdf9d7343a99aa569e2c5c8d15cbe915c9b4f493736b277bfae89"},
+    {file = "dbus_fast-1.22.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dc3323ec405a0f5660dbf8dd632011e56a3a01040316a5cec9c062a0a930aadf"},
+    {file = "dbus_fast-1.22.0-cp37-cp37m-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:327b3903470ce66075952ab6f59abf5a3d81b6a34ca76f5afd0295a224079b96"},
+    {file = "dbus_fast-1.22.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7367fe0d25d2f7f2e7e4da65527e03b5f05295e2f8d3189bdda6b5cdcf41079"},
+    {file = "dbus_fast-1.22.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:49def23a08f459af4cd8e9170fda7ac191b8577108d355a1914c7c862dfa6eb9"},
+    {file = "dbus_fast-1.22.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:31a6ebd1bad2fa9681482f56071d7fab7e21e5f2e280460ef90bf98d48a0addf"},
+    {file = "dbus_fast-1.22.0-cp38-cp38-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:33a79590a38ee0956e8e5f89dd7fb230743a2b630a83e6636440e90000274eaf"},
+    {file = "dbus_fast-1.22.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cf40664a8d647f09687d1ea9bcac959f78eaf8afca90cff7faa0a655307fe7b"},
+    {file = "dbus_fast-1.22.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:0a0e569caffc67614a033e2841b13a123537ff4959e10a571d3cb1fd07b1ed6c"},
+    {file = "dbus_fast-1.22.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a7b0c733fad74be2864dfbc54be39e6efac1499ebeddacd9f8d3ca8cabc54816"},
+    {file = "dbus_fast-1.22.0-cp39-cp39-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:d7141f4d550c8b52a005087a54880727b52fbaeafc6850481f7a4aa9fd7fd32b"},
+    {file = "dbus_fast-1.22.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9f7c977714608de03d5c98851ae2f95b86f06f6bca0a94868653ba284ba305b"},
+    {file = "dbus_fast-1.22.0-cp39-cp39-manylinux_2_31_x86_64.whl", hash = "sha256:905730fd9ca77ff0e7c7927b58542a07169ad75712363bab2281e5c2b807dc86"},
+    {file = "dbus_fast-1.22.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a9fc041966d5422b77c5814a42b495157bf3626902a50a803c4a815f85f035aa"},
+    {file = "dbus_fast-1.22.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b8e0de8daa007ab6d24237d53d9198ddcea43d30ae4d942565dc7d0b6decd791"},
+    {file = "dbus_fast-1.22.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:8321e36f3cfce490ad0ac278a6a79b5aad5542c9c7224c7d131fa156b093b0a9"},
+    {file = "dbus_fast-1.22.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4d1a55211a0f81a8701d48b2d2a71747e70a45bde042e1dabb7d5db024dbaa0"},
+    {file = "dbus_fast-1.22.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:71ecafd6b994a19bdfa4d34c88b7917d7bc3fcae86b26007ff10dcea41a67afd"},
+    {file = "dbus_fast-1.22.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:943fcdcd0aef6923e1da6472abf64f3cca6d47b6f733b464887821032889c673"},
+    {file = "dbus_fast-1.22.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux_2_5_i686.manylinux1_i686.manylinux2014_i686.whl", hash = "sha256:0da4f7288236f89c9d25a4ba56a9f3990ae92f1369dfdfa3dad2fc6c9df7de74"},
+    {file = "dbus_fast-1.22.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0b037c4244002bcf7ae93b0e9eff3533b5feaa6b658ee64c432773afd6c0167"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyobjc-core = { version = "^8.5.1", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5.1", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5.1", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.2.0", markers = "platform_system=='Windows'" }
-dbus-fast = { version = "^1.4.0", markers = "platform_system == 'Linux'" }
+dbus-fast = { version = "^1.22.0", markers = "platform_system == 'Linux'" }
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }


### PR DESCRIPTION
Add a class `pythonic.BleakPythonicClient` that has extra methods `read_gatt_char_typed()` and `write_gatt_char_typed()`.

These method read and write Python values, and the type conversion and marshalling to/from byte strings is governed by the `2904` descriptors provided by the BLE server.